### PR TITLE
Fix python3 support

### DIFF
--- a/gdapi.py
+++ b/gdapi.py
@@ -479,8 +479,7 @@ class Client(object):
                     # a better way to do this
                     cb = lambda type_name=type_name, method=m: \
                         lambda *args, **kw: method(type_name, *args, **kw)
-                    if hasattr(type, type_collection) and \
-                            test_method in typ[type_collection]:
+                    if test_method in getattr(typ, type_collection, []):
                         setattr(self, '_'.join([method_name, name_variant]),
                                 cb())
 

--- a/gdapi.py
+++ b/gdapi.py
@@ -397,7 +397,7 @@ class Client(object):
                 return self._delete(i.links.self)
 
     def action(self, obj, action_name, *args, **kw):
-        url = obj.actions[action_name]
+        url = getattr(obj.actions, action_name)
         return self._post(url, data=self._to_dict(*args, **kw))
 
     def _is_list(self, obj):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-argcomplete==0.7.0
-requests==2.2.1
+argcomplete
+requests
 six

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('./requirements.txt') as r:
 
 setup(
     name='gdapi-python',
-    version='0.5.1',
+    version='0.5.2',
     py_modules=['gdapi'],
     url='https://github.com/godaddy/gdapi-python',
     license='MIT Style',


### PR DESCRIPTION
Fix method bindings for API client instance currently broken because of recent refactoring that adds python3 support. Tested on both python2.7 and python3.4.
